### PR TITLE
Fix test to check error message

### DIFF
--- a/test.js
+++ b/test.js
@@ -35,7 +35,8 @@ test('rejects if any of the input promises reject', async t => {
 		m({
 			foo: Promise.resolve(1),
 			bar: Promise.reject(new Error('bar'))
-		}, 'bar')
+		}),
+		'bar'
 	);
 });
 


### PR DESCRIPTION
Just noticed that the `message` was passed to the module instead of `t.throws`, because of this the error message wasn't checked.