### PR TITLE
Improve TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export default function pProps<
 	options?: Options
 ): Promise<Map<KeyType, MappedValueType>>;
 export default function pProps<
-	InputType extends object,
+	InputType extends {[key: string]: any},
 	ValueType extends InputType[keyof InputType],
 	MappedValueType = PromiseResult<ValueType>
 >(

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
 import {Options} from 'p-map';
 
+export type PromiseResult<Value> = Value extends PromiseLike<infer Result> ? Result : Value;
+
 export type Mapper<ValueType, KeyType, MappedValueType> = (
-	element: PromiseLike<ValueType> | ValueType,
+	element: ValueType,
 	key: KeyType
 ) => MappedValueType | PromiseLike<MappedValueType>;
 
@@ -16,18 +18,18 @@ export type Mapper<ValueType, KeyType, MappedValueType> = (
 export default function pProps<
 	KeyType extends unknown,
 	ValueType extends unknown,
-	MappedValueType = ValueType
+	MappedValueType = PromiseResult<ValueType>
 >(
-	input: Map<KeyType, PromiseLike<ValueType> | ValueType>,
+	input: Map<KeyType, ValueType>,
 	mapper?: Mapper<ValueType, KeyType, MappedValueType>,
 	options?: Options
 ): Promise<Map<KeyType, MappedValueType>>;
 export default function pProps<
 	KeyType extends string,
 	ValueType extends unknown,
-	MappedValueType = ValueType
+	MappedValueType = PromiseResult<ValueType>
 >(
-	input: {[key in KeyType]: PromiseLike<ValueType> | ValueType},
+	input: {[key in KeyType]: ValueType},
 	mapper?: Mapper<ValueType, KeyType, MappedValueType>,
 	options?: Options
 ): Promise<{[key in KeyType]: MappedValueType}>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,13 +25,13 @@ export default function pProps<
 	options?: Options
 ): Promise<Map<KeyType, MappedValueType>>;
 export default function pProps<
-	KeyType extends string,
-	ValueType extends unknown,
+	InputType extends object,
+	ValueType extends InputType[keyof InputType],
 	MappedValueType = PromiseResult<ValueType>
 >(
-	input: {[key in KeyType]: ValueType},
-	mapper?: Mapper<ValueType, KeyType, MappedValueType>,
+	input: InputType,
+	mapper?: Mapper<ValueType, keyof InputType, MappedValueType>,
 	options?: Options
-): Promise<{[key in KeyType]: MappedValueType}>;
+): Promise<{[key in keyof InputType]: MappedValueType}>;
 
 export {Options} from 'p-map';

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export default function pProps<
 	options?: Options
 ): Promise<Map<KeyType, MappedValueType>>;
 export default function pProps<
-	InputType extends {[key: string]: any},
+	InputType extends {[key: string]: unknown},
 	ValueType extends InputType[keyof InputType],
 	MappedValueType = PromiseResult<ValueType>
 >(

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -50,7 +50,7 @@ expectType<Promise<{[key in 'unicorn' | 'foo']: boolean}>>(
 	)
 );
 
-const partialMap: { foo?: Promise<string> } = {}
+const partialMap: {foo?: Promise<string>} = {}
 expectType<Promise<{foo?: string}>>(pProps(partialMap));
 
 const map = new Map<number, string | Promise<string>>([

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -63,20 +63,20 @@ pProps(map).then(result => {
 });
 
 expectType<Promise<Map<number, string>>>(pProps(map));
-expectType<Promise<Map<number, boolean>>>(
+expectType<Promise<Map<number, number>>>(
 	pProps(map, (value, key) => {
 		expectType<string | Promise<string>>(value);
 		expectType<number>(key);
-		return Math.random() > 0.5 ? false : Promise.resolve(true);
+		return Math.random() > 0.5 ? 1 : Promise.resolve(2);
 	})
 );
-expectType<Promise<Map<number, boolean>>>(
+expectType<Promise<Map<number, number>>>(
 	pProps(
 		map,
 		(value, key) => {
 			expectType<string | Promise<string>>(value);
 			expectType<number>(key);
-			return Math.random() > 0.5 ? false : Promise.resolve(true);
+			return Math.random() > 0.5 ? 1 : Promise.resolve(2);
 		},
 		{
 			concurrency: 1

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,7 +4,7 @@ import pProps from '.';
 expectType<Promise<{[key in 'foo']: string}>>(pProps({foo: 'bar'}));
 expectType<Promise<{[key in 'foo']: boolean}>>(
 	pProps({foo: 'bar'}, (value, key) => {
-		expectType<string | PromiseLike<string>>(value);
+		expectType<string>(value);
 		expectType<'foo'>(key);
 		return Math.random() > 0.5 ? false : Promise.resolve(true);
 	})
@@ -13,7 +13,7 @@ expectType<Promise<{[key in 'foo']: boolean}>>(
 	pProps(
 		{foo: 'bar'},
 		(value, key) => {
-			expectType<string | PromiseLike<string>>(value);
+			expectType<string>(value);
 			expectType<'foo'>(key);
 			return Math.random() > 0.5 ? false : Promise.resolve(true);
 		},
@@ -29,20 +29,20 @@ const hashMap = {
 };
 
 expectType<Promise<{[key: string]: string | number}>>(
-	pProps<string, string | number>(hashMap)
+	pProps<string, string | Promise<number>>(hashMap)
 );
 expectType<Promise<{[key: string]: boolean}>>(
-	pProps<string, string | number, boolean>(hashMap, (value, key) => {
-		expectType<string | number | PromiseLike<string | number>>(value);
+	pProps<string, string | Promise<number>, boolean>(hashMap, (value, key) => {
+		expectType<string | Promise<number>>(value);
 		expectType<string>(key);
 		return Math.random() > 0.5 ? false : Promise.resolve(true);
 	})
 );
 expectType<Promise<{[key: string]: boolean}>>(
-	pProps<string, string | number, boolean>(
+	pProps<string, string | Promise<number>, boolean>(
 		hashMap,
 		(value, key) => {
-			expectType<string | number | PromiseLike<string | number>>(value);
+			expectType<string | Promise<number>>(value);
 			expectType<string>(key);
 			return Math.random() > 0.5 ? false : Promise.resolve(true);
 		},
@@ -64,7 +64,7 @@ pProps(map).then(result => {
 expectType<Promise<Map<number, string>>>(pProps(map));
 expectType<Promise<Map<number, boolean>>>(
 	pProps(map, (value, key) => {
-		expectType<string | PromiseLike<string>>(value);
+		expectType<string | Promise<string>>(value);
 		expectType<number>(key);
 		return Math.random() > 0.5 ? false : Promise.resolve(true);
 	})
@@ -73,7 +73,7 @@ expectType<Promise<Map<number, boolean>>>(
 	pProps(
 		map,
 		(value, key) => {
-			expectType<string | PromiseLike<string>>(value);
+			expectType<string | Promise<string>>(value);
 			expectType<number>(key);
 			return Math.random() > 0.5 ? false : Promise.resolve(true);
 		},

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -28,18 +28,16 @@ const hashMap = {
 	foo: 'bar'
 };
 
-expectType<Promise<{[key: string]: string | number}>>(
-	pProps<string, string | Promise<number>>(hashMap)
-);
-expectType<Promise<{[key: string]: boolean}>>(
-	pProps<string, string | Promise<number>, boolean>(hashMap, (value, key) => {
+expectType<Promise<{[key in 'unicorn' | 'foo']: string | number}>>(pProps(hashMap));
+expectType<Promise<{[key in 'unicorn' | 'foo']: boolean}>>(
+	pProps(hashMap, (value, key) => {
 		expectType<string | Promise<number>>(value);
 		expectType<string>(key);
 		return Math.random() > 0.5 ? false : Promise.resolve(true);
 	})
 );
-expectType<Promise<{[key: string]: boolean}>>(
-	pProps<string, string | Promise<number>, boolean>(
+expectType<Promise<{[key in 'unicorn' | 'foo']: boolean}>>(
+	pProps(
 		hashMap,
 		(value, key) => {
 			expectType<string | Promise<number>>(value);
@@ -51,6 +49,9 @@ expectType<Promise<{[key: string]: boolean}>>(
 		}
 	)
 );
+
+const partialMap: { foo?: Promise<string> } = {}
+expectType<Promise<{foo?: string}>>(pProps(partialMap));
 
 const map = new Map<number, string | Promise<string>>([
 	[1, Promise.resolve('1')],

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -59,6 +59,7 @@ const map = new Map<number, string | Promise<string>>([
 ]);
 
 pProps(map).then(result => {
+	expectType<Map<number, string>>(result);
 	expectType<string | undefined>(result.get(1));
 });
 


### PR DESCRIPTION
1. Before using `pProps` always required handling of `element` as a promise, because it had type `PromiseLike<ValueType> | ValueType`, even when it couldn't appear there. Now promise is there only if `ValueType` is supposed to have it.

2. Fixed use of `input` object with optional properties
	```ts
	const partialMap: { foo?: Promise<string> } = {};
	// Was invalid before
	pProps(partialMap);
	```