### PR TITLE
Bump p-map dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"p-map": "^3.0.0"
+		"p-map": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "^2.0.0",


### PR DESCRIPTION
To avoid p-map duplication when p-props and p-map are used