### PR TITLE
Merge map and object handling and require Node.js 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 14
           - 12
-          - 10
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/index.js
+++ b/index.js
@@ -7,17 +7,8 @@ const pProps = (input, mapper = (value => value), options) => {
 	const entries = isMap ? [...map.entries()] : Object.entries(map);
 	const awaitedEntries = entries.map(async ([key, value]) => [key, await value]);
 	const values = await pMap(awaitedEntries, ([key, value]) => mapper(value, key), options);
-	const result = isMap ? new Map() : {};
-
-	for (const [index, key] of entries) {
-		if (isMap) {
-			result.set(key, values[index]);
-		} else {
-			result[key] = values[index];
-		}
-	}
-
-	return result;
+	const mappedEntries = values.map((value, index) => [entries[index], value]);
+	return isMap ? new Map(mappedEntries) : Object.fromEntries(mappedEntries);
 };
 
 module.exports = pProps;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const pMap = require('p-map');
 
-const pProps = (input, mapper, options) => {
+const pProps = async (input, mapper, options) => {
 	const isMap = input instanceof Map;
 	const entries = isMap ? [...map.entries()] : Object.entries(map);
 	const awaitedEntries = entries.map(async ([key, value]) => [key, await value]);

--- a/index.js
+++ b/index.js
@@ -1,16 +1,12 @@
 'use strict';
 const pMap = require('p-map');
 
-const pProps = async (input, mapper, options) => {
+const pProps = async (input, mapper = (value => value), options = undefined) => {
 	const isMap = input instanceof Map;
-	const entries = isMap ? [...map.entries()] : Object.entries(map);
-	const awaitedEntries = entries.map(async ([key, value]) => [key, await value]);
-	if (!mapper && !options) {
-		return isMap ? new Map(awaitedEntries) : Object.fromEntries(awaitedEntries);
-	}
-
-	const values = await pMap(awaitedEntries, ([key, value]) => mapper(value, key), options);
-	const mappedEntries = awaitedEntries.map(([key], index) => [key, value[index]]);
+	const entries = isMap ? [...input.entries()] : Object.entries(input);
+	const promisedEntries = entries.map(async ([key, value]) => [key, await value]);
+	const values = await pMap(promisedEntries, ([key, value]) => mapper(value, key), options);
+	const mappedEntries = entries.map(([key], index) => [key, values[index]]);
 	return isMap ? new Map(mappedEntries) : Object.fromEntries(mappedEntries);
 };
 

--- a/index.js
+++ b/index.js
@@ -1,35 +1,23 @@
 'use strict';
 const pMap = require('p-map');
 
-const map = async (map, mapper, options) => {
-	const awaitedEntries = [...map.entries()].map(async ([key, value]) => [key, await value]);
-	const values = await pMap(awaitedEntries, ([key, value]) => mapper(value, key), options);
-	const result = new Map();
-
-	for (const [index, key] of [...map.keys()].entries()) {
-		result.set(key, values[index]);
-	}
-
-	return result;
-};
-
-const object = async (map, mapper, options) => {
-	const awaitedEntries = Object.entries(map).map(async ([key, value]) => [key, await value]);
-	const values = await pMap(awaitedEntries, ([key, value]) => mapper(value, key), options);
-	const result = {};
-
-	for (const [index, key] of Object.keys(map).entries()) {
-		result[key] = values[index];
-	}
-
-	return result;
-};
-
 // eslint-disable-next-line default-param-last
 const pProps = (input, mapper = (value => value), options) => {
-	return input instanceof Map ?
-		map(input, mapper, options) :
-		object(input, mapper, options);
+	const isMap = input instanceof Map;
+	const entries = isMap ? [...map.entries()] : Object.entries(map);
+	const awaitedEntries = entries.map(async ([key, value]) => [key, await value]);
+	const values = await pMap(awaitedEntries, ([key, value]) => mapper(value, key), options);
+	const result = isMap ? new Map() : {};
+
+	for (const [index, key] of entries) {
+		if (isMap) {
+			result.set(key, values[index]);
+		} else {
+			result[key] = values[index];
+		}
+	}
+
+	return result;
 };
 
 module.exports = pProps;

--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ const pMap = require('p-map');
 const pProps = async (input, mapper = (value => value), options = undefined) => {
 	const isMap = input instanceof Map;
 	const entries = isMap ? [...input.entries()] : Object.entries(input);
-	const promisedEntries = entries.map(async ([key, value]) => [key, await value]);
-	const values = await pMap(promisedEntries, ([key, value]) => mapper(value, key), options);
+	const values = await pMap(entries, async ([key, value]) => mapper(await value, key), options);
 	const mappedEntries = entries.map(([key], index) => [key, values[index]]);
 	return isMap ? new Map(mappedEntries) : Object.fromEntries(mappedEntries);
 };

--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ const pProps = (input, mapper, options) => {
 	const entries = isMap ? [...map.entries()] : Object.entries(map);
 	const awaitedEntries = entries.map(async ([key, value]) => [key, await value]);
 	if (!mapper && !options) {
-		return isMap ? new Map(awaitedEntries) : Object.fromEntries(awaitedEntries)
+		return isMap ? new Map(awaitedEntries) : Object.fromEntries(awaitedEntries);
 	}
 
 	const values = await pMap(awaitedEntries, ([key, value]) => mapper(value, key), options);
-	const mappedEntries = values.map((value, index) => [entries[index], value]);
+	const mappedEntries = awaitedEntries.map(([key], index) => [key, value[index]]);
 	return isMap ? new Map(mappedEntries) : Object.fromEntries(mappedEntries);
 };
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 'use strict';
 const pMap = require('p-map');
 
-// eslint-disable-next-line default-param-last
-const pProps = (input, mapper = (value => value), options) => {
+const pProps = (input, mapper, options) => {
 	const isMap = input instanceof Map;
 	const entries = isMap ? [...map.entries()] : Object.entries(map);
 	const awaitedEntries = entries.map(async ([key, value]) => [key, await value]);
+	if (!mapper && !options) {
+		return isMap ? new Map(awaitedEntries) : Object.fromEntries(awaitedEntries)
+	}
+
 	const values = await pMap(awaitedEntries, ([key, value]) => mapper(value, key), options);
 	const mappedEntries = values.map((value, index) => [entries[index], value]);
 	return isMap ? new Map(mappedEntries) : Object.fromEntries(mappedEntries);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">=12"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
This also solves an issue where it would break if the source object/map was changed while the map is being awaited (because `.entries()` was being called a second time on the source object, and the following loop was actually index-sensitive)